### PR TITLE
fix(prediction/sph_harm): handle scipy 1.15 sph_harm_y API change

### DIFF
--- a/src/seap/prediction/sph_harm.py
+++ b/src/seap/prediction/sph_harm.py
@@ -1,9 +1,26 @@
 import numpy as np
+
+# scipy changed the spherical-harmonic API in 1.15:
+#   sph_harm    (deprecated): sph_harm(m, n, theta, phi)  with
+#                             theta = azimuthal in [0, 2pi],
+#                             phi   = polar     in [0, pi].
+#   sph_harm_y  (>= 1.15):    sph_harm_y(n, m, theta, phi) with
+#                             theta = polar     in [0, pi],
+#                             phi   = azimuthal in [0, 2pi].
+# Both the (m, n) order *and* the meaning of theta/phi are inverted.
+# We expose a single helper _Ylm(l, m, phi_az, theta_pol) that always evaluates
+# Y_l^m(theta_pol, phi_az) with the standard physics convention.
 try:
-    from scipy.special import sph_harm_y as _sph_harm
+    from scipy.special import sph_harm_y as _scipy_sph
+    def _Ylm(l, m, phi_az, theta_pol):
+        # sph_harm_y(n=l, m=m, theta=theta_pol, phi=phi_az)
+        return _scipy_sph(l, m, theta_pol, phi_az)
 except ImportError:
-    # Fallback for older scipy versions
-    from scipy.special import sph_harm as _sph_harm
+    from scipy.special import sph_harm as _scipy_sph
+    def _Ylm(l, m, phi_az, theta_pol):
+        # sph_harm(m=m, n=l, theta=phi_az, phi=theta_pol)
+        return _scipy_sph(m, l, phi_az, theta_pol)
+
 
 def spherical_harmonics(l, m, theta, phi):
     """
@@ -28,13 +45,13 @@ def spherical_harmonics(l, m, theta, phi):
     """
     if m > 0:
         # For positive m, return the real part multiplied by sqrt(2) and (-1)^m
-        return np.sqrt(2) * (-1)**m * _sph_harm(m, l, phi, theta).real
+        return np.sqrt(2) * (-1)**m * _Ylm(l, m, phi, theta).real
     if m < 0:
         # For negative m, return the imaginary part multiplied by sqrt(2) and (-1)^m
-        return np.sqrt(2) * (-1)**m * _sph_harm(-m, l, phi, theta).imag
+        return np.sqrt(2) * (-1)**m * _Ylm(l, -m, phi, theta).imag
     else:
         # For m = 0, return the real part
-        return _sph_harm(m, l, phi, theta).real
+        return _Ylm(l, m, phi, theta).real
 
 def quantum_number(n):
     """

--- a/tests/test_sph_harm.py
+++ b/tests/test_sph_harm.py
@@ -167,8 +167,130 @@ class TestGenerateSMat:
         """Test that import fallback mechanism works."""
         # Test that the try-except import block is covered
         from seap.prediction import sph_harm as sph
-        # The module should have _sph_harm imported (either sph_harm_y or sph_harm)
-        # We can't directly test the import, but we can test that functions work
+        # The module should expose a working spherical_harmonics regardless
+        # of which scipy backend (sph_harm or sph_harm_y) was imported by
+        # the wrapper. We can't directly test the import, but we can test
+        # that the function works.
         result = sph.spherical_harmonics(0, 0, np.array([0.0]), np.array([0.0]))
         assert isinstance(result, np.ndarray)
+
+
+class TestSphericalHarmonicsValues:
+    """Regression tests for the numerical values of the real spherical
+    harmonics produced by spherical_harmonics().
+
+    These tests guard against API-mapping regressions of the form that
+    motivated the SciPy 1.15 fix: a silent rebinding of the underlying
+    scipy function (sph_harm vs. sph_harm_y) without updating the
+    argument order or the meaning of theta/phi caused every l > 0
+    channel to return zero on the standard physics convention. The
+    earlier shape/type tests in this file would not have caught that.
+
+    Reference values use the standard real spherical harmonics
+    convention,
+        Y_{l, m>0} = sqrt(2) * (-1)^m * Re[Y_l^m(complex)]
+        Y_{l, m<0} = sqrt(2) * (-1)^m * Im[Y_l^|m|(complex)]
+        Y_{l, 0}   =                Re[Y_l^0(complex)]
+    matching the wrapper in seap.prediction.sph_harm. Reference angles
+    are chosen so that closed-form values from the standard tables
+    apply directly.
+    """
+
+    TOL = 1e-10
+
+    def test_Y00_constant(self):
+        """Y_{0,0} = 1 / (2 sqrt(pi)) regardless of (theta, phi)."""
+        expected = 1.0 / (2.0 * np.sqrt(np.pi))
+        for theta, phi in [(0.0, 0.0), (np.pi / 3, np.pi / 4), (np.pi, 1.7)]:
+            val = spherical_harmonics(0, 0, np.array([theta]), np.array([phi]))
+            assert abs(val[0] - expected) < self.TOL
+
+    def test_Y10_along_axes(self):
+        """Y_{1,0}(theta) = sqrt(3 / (4 pi)) cos(theta)."""
+        c = np.sqrt(3.0 / (4.0 * np.pi))
+        # theta=0 -> +c; theta=pi -> -c; theta=pi/2 -> 0.
+        v = spherical_harmonics(1, 0,
+                                np.array([0.0, np.pi, np.pi / 2]),
+                                np.array([0.0, 0.0, 0.0]))
+        assert abs(v[0] - c) < self.TOL
+        assert abs(v[1] + c) < self.TOL
+        assert abs(v[2]) < self.TOL
+
+    def test_Y1pm1_in_xy_plane(self):
+        """At theta = pi/2:
+            Y_{1, 1}(phi)  = sqrt(3 / (4 pi)) cos(phi)
+            Y_{1,-1}(phi)  = sqrt(3 / (4 pi)) sin(phi)
+        """
+        c = np.sqrt(3.0 / (4.0 * np.pi))
+        phi = np.array([0.0, np.pi / 2])
+        theta = np.full_like(phi, np.pi / 2)
+        v_p = spherical_harmonics(1, 1, theta, phi)
+        v_m = spherical_harmonics(1, -1, theta, phi)
+        # Y_{1, 1}: phi=0 -> +c; phi=pi/2 -> 0.
+        assert abs(v_p[0] - c) < self.TOL
+        assert abs(v_p[1]) < self.TOL
+        # Y_{1,-1}: phi=0 -> 0; phi=pi/2 -> +c.
+        assert abs(v_m[0]) < self.TOL
+        assert abs(v_m[1] - c) < self.TOL
+
+    def test_Y20_along_z(self):
+        """Y_{2,0}(theta) = (1/4) sqrt(5 / pi) (3 cos^2(theta) - 1)."""
+        coef = 0.25 * np.sqrt(5.0 / np.pi)
+        v = spherical_harmonics(
+            2, 0,
+            np.array([0.0, np.pi / 2]),
+            np.array([0.0, 0.0]))
+        assert abs(v[0] - coef * 2.0) < self.TOL          # theta=0
+        assert abs(v[1] - coef * (-1.0)) < self.TOL       # theta=pi/2
+
+    def test_Y2pm2_in_xy_plane(self):
+        """At theta = pi/2:
+            Y_{2, 2}(phi) = (1/4) sqrt(15 / pi) cos(2 phi)
+            Y_{2,-2}(phi) = (1/4) sqrt(15 / pi) sin(2 phi)
+        """
+        coef = 0.25 * np.sqrt(15.0 / np.pi)
+        phi = np.array([0.0, np.pi / 4])
+        theta = np.full_like(phi, np.pi / 2)
+        v_p = spherical_harmonics(2, 2, theta, phi)
+        v_m = spherical_harmonics(2, -2, theta, phi)
+        # Y_{2, 2}: phi=0 -> +coef; phi=pi/4 -> 0.
+        assert abs(v_p[0] - coef) < self.TOL
+        assert abs(v_p[1]) < self.TOL
+        # Y_{2,-2}: phi=0 -> 0; phi=pi/4 -> +coef.
+        assert abs(v_m[0]) < self.TOL
+        assert abs(v_m[1] - coef) < self.TOL
+
+    def test_no_silent_zero_channel(self):
+        """Every (l, m) channel for 0 <= l <= 3 must produce non-zero
+        values at some angle. The SciPy 1.15 sph_harm_y API change
+        previously caused all m != 0 channels to return zero
+        identically; this regression test catches a recurrence."""
+        rng = np.random.default_rng(seed=1234)
+        theta = rng.uniform(0.05, np.pi - 0.05, size=128)
+        phi = rng.uniform(0.0, 2.0 * np.pi, size=128)
+        for l in range(4):
+            for m in range(-l, l + 1):
+                vals = spherical_harmonics(l, m, theta, phi)
+                assert isinstance(vals, np.ndarray)
+                assert np.any(np.abs(vals) > 1e-6), (
+                    f"All values are zero for (l, m) = ({l}, {m}); "
+                    "spherical_harmonics wrapper has regressed.")
+
+    def test_sum_rule_per_l(self):
+        """Unsoeld's sum rule for real spherical harmonics:
+            sum_{m = -l..l} Y_{l, m}(theta, phi)^2 = (2 l + 1) / (4 pi)
+        for any (theta, phi). This is independent of the (m, n)
+        argument order convention, so it is a strong cross-check on
+        the wrapper across SciPy versions."""
+        rng = np.random.default_rng(seed=5678)
+        theta = rng.uniform(0.05, np.pi - 0.05, size=32)
+        phi = rng.uniform(0.0, 2.0 * np.pi, size=32)
+        for l in range(4):
+            total = np.zeros_like(theta)
+            for m in range(-l, l + 1):
+                total += spherical_harmonics(l, m, theta, phi) ** 2
+            expected = (2 * l + 1) / (4.0 * np.pi)
+            assert np.allclose(total, expected, atol=1e-10), (
+                f"Sum rule violated for l = {l}: "
+                f"got mean {total.mean():.6e}, expected {expected:.6e}.")
 


### PR DESCRIPTION
SciPy 1.15 replaced scipy.special.sph_harm with sph_harm_y, inverting *both* the (m, n) -> (n, m) argument order and the meaning of theta/phi:

  sph_harm   (deprecated): sph_harm(m, n, theta_az, phi_pol)
  sph_harm_y (>= 1.15):    sph_harm_y(n, m, theta_pol, phi_az)

The previous try/except ImportError only swapped the binding name, leaving every call site as _sph_harm(m, l, phi, theta) -- correct under the legacy API, wrong under sph_harm_y. As a result, on scipy >= 1.15 every l>0 channel (9 of 16 spherical-harmonic outputs in our l_max=3 setup) silently returned zero. The discrete normalization integral collapsed from ~1.0 to ~0.27 and <|psi|^2> dropped from ~1e-3 to ~2.7e-4 on the 32^3 grid with L=10, distorting all downstream training data and the reported MSE band.

This commit wraps both APIs in a single helper _Ylm(l, m, phi_az, theta_pol) that always evaluates Y_l^m(theta_pol, phi_az) in the standard physics convention regardless of which scipy version is installed; the three call sites in spherical_harmonics() are updated accordingly. No behavior change on scipy < 1.15.